### PR TITLE
Make adding vendor requests easier

### DIFF
--- a/host/greatfet/protocol/vendor_requests.py
+++ b/host/greatfet/protocol/vendor_requests.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2016 Kyle J. Temkin <kyle@ktemkin.com>
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or without 
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #
 # 1. Redistributions of source code must retain the above copyright notice,
@@ -39,28 +39,28 @@ requests that may differ from base-board to base-board.
 
 # Internal programming requests.
 INIT_SPIFLASH = 0
-WRITE_SPIFLASH = 1
-READ_SPIFLASH = 2
-ERASE_SPIFLASH = 3
+WRITE_SPIFLASH = INIT_SPIFLASH + 1
+READ_SPIFLASH = WRITE_SPIFLASH + 1
+ERASE_SPIFLASH = READ_SPIFLASH + 1
 
 # Board information API.
-READ_BOARD_ID = 4
-READ_VERSION_STRING = 5
-READ_PARTID_SERIALNO = 6
+READ_BOARD_ID = ERASE_SPIFLASH + 1
+READ_VERSION_STRING = READ_BOARD_ID + 1
+READ_PARTID_SERIALNO = READ_VERSION_STRING + 1
 
 # Temporary, custom stuffs?
-ENABLE_USB1 = 7
-LED_TOGGLE = 8
+ENABLE_USB1 = READ_PARTID_SERIALNO + 1
+LED_TOGGLE = ENABLE_USB1 + 1
 
-REGISTER_GPIO = 9
-WRITE_GPIO = 10
+REGISTER_GPIO = LED_TOGGLE + 1
+WRITE_GPIO = REGISTER_GPIO + 1
 
-SPI_INIT = 11
-SPI_WRITE = 12
-SPI_READ = 13
-SPI_DUMP_FLASH = 14
+SPI_INIT = WRITE_GPIO + 1
+SPI_WRITE = SPI_INIT + 1
+SPI_READ = SPI_WRITE + 1
+SPI_DUMP_FLASH = SPI_READ + 1
 
-I2C_START = 15
-I2C_STOP = 16
-I2C_XFER = 17
-I2C_RESPONSE = 18
+I2C_START = SPI_DUMP_FLASH + 1
+I2C_STOP = I2C_START + 1
+I2C_XFER = I2C_STOP + 1
+I2C_RESPONSE = I2C_XFER + 1

--- a/host/greatfet/protocol/vendor_requests.py
+++ b/host/greatfet/protocol/vendor_requests.py
@@ -37,30 +37,39 @@ Ideally we'll add an offset (100?) to per-board vendor requests to separate
 requests that may differ from base-board to base-board.
 """
 
-# Internal programming requests.
-INIT_SPIFLASH = 0
-WRITE_SPIFLASH = INIT_SPIFLASH + 1
-READ_SPIFLASH = WRITE_SPIFLASH + 1
-ERASE_SPIFLASH = READ_SPIFLASH + 1
+requests = [
+    # Internal programming requests.
+    'INIT_SPIFLASH',
+    'WRITE_SPIFLASH',
+    'READ_SPIFLASH',
+    'ERASE_SPIFLASH',
 
-# Board information API.
-READ_BOARD_ID = ERASE_SPIFLASH + 1
-READ_VERSION_STRING = READ_BOARD_ID + 1
-READ_PARTID_SERIALNO = READ_VERSION_STRING + 1
+    # Board information API.
+    'READ_BOARD_ID',
+    'READ_VERSION_STRING',
+    'READ_PARTID_SERIALNO',
 
-# Temporary, custom stuffs?
-ENABLE_USB1 = READ_PARTID_SERIALNO + 1
-LED_TOGGLE = ENABLE_USB1 + 1
+    # Temporary, custom stuffs?
+    'ENABLE_USB1',
+    'LED_TOGGLE',
 
-REGISTER_GPIO = LED_TOGGLE + 1
-WRITE_GPIO = REGISTER_GPIO + 1
+    'REGISTER_GPIO',
+    'WRITE_GPIO',
 
-SPI_INIT = WRITE_GPIO + 1
-SPI_WRITE = SPI_INIT + 1
-SPI_READ = SPI_WRITE + 1
-SPI_DUMP_FLASH = SPI_READ + 1
+    'SPI_INIT',
+    'SPI_WRITE',
+    'SPI_READ',
+    'SPI_DUMP_FLASH',
 
-I2C_START = SPI_DUMP_FLASH + 1
-I2C_STOP = I2C_START + 1
-I2C_XFER = I2C_STOP + 1
-I2C_RESPONSE = I2C_XFER + 1
+    'I2C_START',
+    'I2C_STOP',
+    'I2C_XFER',
+    'I2C_RESPONSE'
+]
+
+
+# Get a reference (as an object) to this module (self)
+this_module = globals()
+
+for i in range(len(requests)):
+    this_module[requests[i]] = i


### PR DESCRIPTION
This makes it much easier to add vendor requests before the end, as
each vendor request is based on the one before it. So only the request immediately after the added one has to change.