### PR TITLE
Build and tooling fixes. 

### DIFF
--- a/firmware/cmake/greatfet-common.cmake
+++ b/firmware/cmake/greatfet-common.cmake
@@ -135,12 +135,12 @@ macro(DeclareTargets)
 	)
 
 	# Object files to be linked for both DFU and SPI flash versions
-	add_library(OBJ_FILES OBJECT ${SRC_M4} m0_bin.s)
-	set_target_properties(OBJ_FILES PROPERTIES COMPILE_FLAGS "${CFLAGS_M4}")
+	add_library(OBJ_FILES_${PROJECT_NAME} OBJECT ${SRC_M4} m0_bin.s)
+	set_target_properties(OBJ_FILES_${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "${CFLAGS_M4}")
+	add_dependencies(OBJ_FILES_${PROJECT_NAME} ${PROJECT_NAME}_m0.bin)
 
 	# SPI flash version
-	add_executable(${PROJECT_NAME}.elf $<TARGET_OBJECTS:OBJ_FILES>)
-	add_dependencies(${PROJECT_NAME}.elf ${PROJECT_NAME}_m0.bin)
+	add_executable(${PROJECT_NAME}.elf $<TARGET_OBJECTS:OBJ_FILES_${PROJECT_NAME}>)
 
 	target_link_libraries(
 		${PROJECT_NAME}.elf
@@ -160,8 +160,7 @@ macro(DeclareTargets)
 	)
 
 	# DFU - using a differnet LD script to run directly from RAM
-	add_executable(${PROJECT_NAME}_dfu.elf $<TARGET_OBJECTS:OBJ_FILES>)
-	add_dependencies(${PROJECT_NAME}_dfu.elf ${PROJECT_NAME}_m0.bin)
+	add_executable(${PROJECT_NAME}_dfu.elf $<TARGET_OBJECTS:OBJ_FILES_${PROJECT_NAME}>)
 
 	target_link_libraries(
 		${PROJECT_NAME}_dfu.elf

--- a/host/greatfet_firmware
+++ b/host/greatfet_firmware
@@ -31,6 +31,8 @@
     Utility for flashing the onboard SPI flash on GreatFET boards.
 """
 
+from __future__ import print_function
+
 import sys
 import errno
 import argparse
@@ -88,6 +90,7 @@ def main():
     # If we don't have an option, print our usage.
     if not args.read and not args.write:
         parser.print_help()
+        sys.exit(0)
 
     # Determine whether we're going to log to the stdout, or not at all.
     log_function = log_verbose if args.verbose else log_silent
@@ -99,16 +102,16 @@ def main():
         log_function("{} found. (Serial number: {})".format(device.board_name(), device.serial_number()))
     except DeviceNotFoundError:
         if args.serial:
-            log_function("No GreatFET board found matching serial '{}'.".format(args.serial), file=sys.stderr)
+            print("No GreatFET board found matching serial '{}'.".format(args.serial), file=sys.stderr)
         else:
-            log_function("No GreatFET board found!", file=sys.stderr)
+            print("No GreatFET board found!", file=sys.stderr)
         sys.exit(errno.ENODEV)
 
     # Ensure that the device supports an onboard SPI flash.
     try:
         device.onboard_flash
     except AttributeError:
-        log_function("The attached GreatFET ({}) doesn't appear to have an SPI flash to program!".format(device.board_name()), file=sys.stderr)
+        print("The attached GreatFET ({}) doesn't appear to have an SPI flash to program!".format(device.board_name()), file=sys.stderr)
         sys.exit(errno.ENOSYS)
 
     # If we have a write command, write first, to match the behavior of hackrf_spiflash.

--- a/host/greatfet_logic
+++ b/host/greatfet_logic
@@ -28,6 +28,8 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import print_function
+
 import sys
 import argparse
 
@@ -54,9 +56,9 @@ if __name__ == '__main__':
         log_function("{} found. (Serial number: {})".format(device.board_name(), device.serial_number()))
     except greatfet.errors.DeviceNotFoundError:
         if args.serial:
-            log_function("No GreatFET board found matching serial '{}'.".format(args.serial), file=sys.stderr)
+            print("No GreatFET board found matching serial '{}'.".format(args.serial), file=sys.stderr)
         else:
-            log_function("No GreatFET board found!", file=sys.stderr)
+            print("No GreatFET board found!", file=sys.stderr)
         sys.exit(errno.ENODEV)
 
     device.vendor_request_out(vendor_requests.LOGIC_ANALYZER_START)

--- a/host/greatfet_spiflash
+++ b/host/greatfet_spiflash
@@ -26,6 +26,9 @@
 #  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import print_function
 
 import sys
 import argparse
@@ -143,7 +146,7 @@ if __name__ == '__main__':
     parser.add_argument('-v', dest='verbose', action='store_true', help="Write data from file")
     args = parser.parse_args()
 
-    # If we don't have an option, log_function our usage.
+    # If we don't have an option, print our usage.
     if not args.info and not args.dump:
         parser.print_help()
         sys.exit()
@@ -158,9 +161,9 @@ if __name__ == '__main__':
         log_function("{} found. (Serial number: {})".format(device.board_name(), device.serial_number()))
     except DeviceNotFoundError:
         if args.serial:
-            log_function("No GreatFET board found matching serial '{}'.".format(args.serial), file=sys.stderr)
+            print("No GreatFET board found matching serial '{}'.".format(args.serial), file=sys.stderr)
         else:
-            log_function("No GreatFET board found!", file=sys.stderr)
+            print("No GreatFET board found!", file=sys.stderr)
         sys.exit(errno.ENODEV)
 
     device.vendor_request_out(vendor_requests.SPI_INIT)


### PR DESCRIPTION
Fixes three issues:

- ```m0_bin.s``` (autogenerated) ```incbin```s ```${PROJECT_NAME}_m0.bin```, but cmake isn't aware of the dependency. Add it explicitly to the target that assembles ```m0_bin.s```.
- Some of the ```print``` calls in the greatfet_* utilities were replaced with ```log_function```, even when it wasn't likely to be what we wanted; e.g. an error should always make it to the stderr, even if ```--verbose``` isn't on.
- ```greatfet_firmware``` shouldn't try to connect to a board when it doesn't have any commands to accomplish (e.g. when checking the help text).