### PR TITLE
Select proper clock for the USB I2C API.

### DIFF
--- a/firmware/greatfet_usb/usb_api_i2c.c
+++ b/firmware/greatfet_usb/usb_api_i2c.c
@@ -32,7 +32,7 @@ uint8_t i2c_rx_buffer[255];
 usb_request_status_t usb_vendor_request_i2c_start(
 		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage) {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		i2c_bus_start(&i2c0, &i2c_config_slow_clock);
+		i2c_bus_start(&i2c0, &i2c_config_fast_clock);
 		usb_transfer_schedule_ack(endpoint->in);
 	}
 	return USB_REQUEST_STATUS_OK;


### PR DESCRIPTION
Once a USB connection is made, PLL1 is switched to 'max speed' at 204MHz;
but the current API incorrectly assumes PLL1 will be 48MHz, and selects too
low an I2C scaling factor accordingly.

This switches to the max_speed configuration appropriate for a PLL of 204MHz.