### PR TITLE
Add API for IO Expanders

### DIFF
--- a/host/greatfet/io_expander.py
+++ b/host/greatfet/io_expander.py
@@ -36,10 +36,16 @@ class DIOExpander(object):
     """
     __metaclass__ = ABCMeta
 
+    @abstractmethod
+    def __init__(self):
+        self._pins = 0
+        self._directions = 0
+
     @abstractproperty
     def number_pins(self):
         """Return the number of expanded pins as an integer."""
         return 0
+
 
     @abstractmethod
     def set_direction(self, directions):
@@ -47,20 +53,91 @@ class DIOExpander(object):
         0 represents an input
         1 represents an output
         """
-        return
+        directions = self._validate_port_value(directions)
+        write_directions = directions
+
+        for i in range(self.number_pins):
+            self.set_pin_direction(i, directions & 1)
+            directions = (directions >> 1)
+
+        self._directions = write_directions
+
+    @abstractmethod
+    def set_pin_direction(self, pin_num, direction):
+        pin_num, direction = self._validate_pin_args(pin_num, direction)
+
+        directions = self._set_bit(self._directions, pin_num, direction)
+
+        self.set_direction(directions)
+        self._directions = directions
+
 
     @abstractmethod
     def read(self):
         """Return the value of the pins."""
-        return
+        pin_values = 0
+        for i in range(self.number_pins - 1, -1, -1):
+            pin_values = (pin_values << 1) | self.read_pin(i)
+
+        return pin_values
+
+    @abstractmethod
+    def read_pin(self, pin_num):
+        pin_num = self._validate_pin_number(pin_num)
+
+        return self._git_bit(self.read(), pin_num)
+
 
     @abstractmethod
     def write(self, value):
         """Set the value of the pins."""
-        return
+        value = self._validate_port_value(value)
+        write_value = value
 
-    def _validate_pin_values(self, value):
-        """Ensure the value is in a range that can represent the states of the pins."""
+        for i in range(self.number_pins):
+            self.write_pin(i, value & 1)
+            value = (value >> 1)
+
+        self._pins = write_value
+
+    @abstractmethod
+    def write_pin(self, pin_num, value):
+        pin_num, value = self._validate_pin_args(pin_num, value)
+        write_value = self._set_bit(self._pins, pin_num, value)
+
+        self.write(write_value)
+        self._pins = write_value
+
+
+    def _validate_pin_number(self, pin_num):
+        if pin_num < 0 or pin_num >= self.number_pins:
+            raise ValueError("Tried to access an invalid pin.")
+        return pin_num
+
+    @staticmethod
+    def _validate_pin_value(value):
+        value = int(value)
+        if value < 0 or value > 1:
+            raise ValueError("Tried to set an invalid value for a pin.")
+        return value
+
+    def _validate_port_value(self, value):
+        """Ensure the value is in a range that can represent the state of the pins."""
         if value < 0 or value > self.number_pins ** 2 - 1:
             raise ValueError("Tried to set an invalid value.")
         return value
+
+    def _validate_pin_args(self, pin_num, value):
+        return (self._validate_pin_number(pin_num), self._validate_pin_value(value))
+
+
+    @staticmethod
+    def _set_bit(bits, bit_num, bit_value):
+        if bit_value:
+            return bits | (1 << bit_num)
+        else:
+            return bits & ~(1 << bit_num)
+
+    @staticmethod
+    def _git_bit(bits, bit_num):
+        return (bits >> bit_num) & 1

--- a/host/greatfet/io_expander.py
+++ b/host/greatfet/io_expander.py
@@ -1,0 +1,66 @@
+#
+# Copyright (c) 2016 Schuyler St. Leger <schuyler.st.leger@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+from abc import ABCMeta, abstractmethod, abstractproperty
+
+class GreatFEFDIOExpander(object):
+    """Class representing a generic digital IO expander.
+    Values for the pin states are integers with the least significant bit
+    corresponding to pin 0 on the expander.
+    """
+    __metaclass__ = ABCMeta
+
+    @abstractproperty
+    def get_number_pins(self):
+        """Return the number of expanded pins as an integer."""
+        return 0
+
+    @abstractmethod
+    def set_direction(self, directions):
+        """Set the direction of the pins.
+        0 represents an input
+        1 represents an output
+        """
+        return
+
+    @abstractmethod
+    def read(self):
+        """Return the value of the pins."""
+        return
+
+    @abstractmethod
+    def write(self, value):
+        """Set the value of the pins."""
+        return
+
+    def _validate_pin_values(self, value):
+        """Ensure the value is in a range that can represent the states of the pins."""
+        if value < 0 or value > self.get_number_pins ** 2 - 1:
+            raise ValueError("Tried to set an invalid value.")
+        return value

--- a/host/greatfet/io_expander.py
+++ b/host/greatfet/io_expander.py
@@ -37,7 +37,7 @@ class DIOExpander(object):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def get_number_pins(self):
+    def number_pins(self):
         """Return the number of expanded pins as an integer."""
         return 0
 
@@ -61,6 +61,6 @@ class DIOExpander(object):
 
     def _validate_pin_values(self, value):
         """Ensure the value is in a range that can represent the states of the pins."""
-        if value < 0 or value > self.get_number_pins ** 2 - 1:
+        if value < 0 or value > self.number_pins ** 2 - 1:
             raise ValueError("Tried to set an invalid value.")
         return value

--- a/host/greatfet/io_expander.py
+++ b/host/greatfet/io_expander.py
@@ -29,7 +29,7 @@
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 
-class GreatFEFDIOExpander(object):
+class DIOExpander(object):
     """Class representing a generic digital IO expander.
     Values for the pin states are integers with the least significant bit
     corresponding to pin 0 on the expander.

--- a/host/greatfet/io_expander.py
+++ b/host/greatfet/io_expander.py
@@ -60,8 +60,6 @@ class DIOExpander(object):
             self.set_pin_direction(i, directions & 1)
             directions = (directions >> 1)
 
-        self._directions = write_directions
-
     @abstractmethod
     def set_pin_direction(self, pin_num, direction):
         pin_num, direction = self._validate_pin_args(pin_num, direction)
@@ -69,7 +67,6 @@ class DIOExpander(object):
         directions = self._set_bit(self._directions, pin_num, direction)
 
         self.set_direction(directions)
-        self._directions = directions
 
 
     @abstractmethod
@@ -98,15 +95,12 @@ class DIOExpander(object):
             self.write_pin(i, value & 1)
             value = (value >> 1)
 
-        self._pins = write_value
-
     @abstractmethod
     def write_pin(self, pin_num, value):
         pin_num, value = self._validate_pin_args(pin_num, value)
         write_value = self._set_bit(self._pins, pin_num, value)
 
         self.write(write_value)
-        self._pins = write_value
 
 
     def _validate_pin_number(self, pin_num):

--- a/host/greatfet/io_expander.py
+++ b/host/greatfet/io_expander.py
@@ -123,7 +123,7 @@ class DIOExpander(object):
 
     def _validate_port_value(self, value):
         """Ensure the value is in a range that can represent the state of the pins."""
-        if value < 0 or value > self.number_pins ** 2 - 1:
+        if value < 0 or value > 2 ** self.number_pins - 1:
             raise ValueError("Tried to set an invalid value.")
         return value
 

--- a/host/greatfet/io_expanders/pca9674.py
+++ b/host/greatfet/io_expanders/pca9674.py
@@ -31,7 +31,7 @@
 from ..io_expander import DIOExpander
 from ..peripherals.i2c_device import I2CDevice
 
-class PCA9674(I2CDevice, DIOExpander):
+class PCA9674(DIOExpander, I2CDevice):
     """PCA9674 I²C I/O expander"""
 
     def __init__(self, bus, address=0x20):
@@ -42,20 +42,42 @@ class PCA9674(I2CDevice, DIOExpander):
                 GreatFET One, this would typically be (board.i2c).
             address: Optional; used to specify a non-default address.
         """
+        super(PCA9674, self).__init__()
+        I2CDevice.__init__(self, bus, address, 'PCA9674')
 
-        super(PCA9674, self).__init__(bus, address, 'PCA9674')
+        # Power up value of pins with the PCA9674
+        self._pins = 0xFF
 
     @property
     def number_pins(self):
         return 8
 
+
     def set_direction(self, value):
+        value = self._validate_port_value(value)
+
         # Invert value
         pin_states = ~value & 2**self.number_pins - 1
+
         self.transmit(pin_states, 0)
+        self._directions = pin_states
+
+    def set_pin_direction(self, pin_num, direction):
+        super(PCA9674, self).set_pin_direction(pin_num, direction)
+
 
     def read(self):
         return self.transmit([], 1)[0]
 
+    def read_pin(self, pin_num):
+        return super(PCA9674, self).read_pin(pin_num)
+
+
     def write(self, value):
-        self.transmit([self._validate_pin_values(value)])
+        value = self._validate_port_value(value)
+
+        self.transmit([value], 0)
+        self._pins = value
+
+    def write_pin(self, pin_num, value):
+        super(PCA9674, self).write_pin(pin_num, value)

--- a/host/greatfet/io_expanders/pca9674.py
+++ b/host/greatfet/io_expanders/pca9674.py
@@ -41,6 +41,7 @@ class PCA9674(DIOExpander, I2CDevice):
             bus: I²C bus the IO PCA9674 is connected to. For a
                 GreatFET One, this would typically be (board.i2c).
             address: Optional; used to specify a non-default address.
+                This is the 7 bit address of the PCA9674.
         """
         super(PCA9674, self).__init__()
         I2CDevice.__init__(self, bus, address, 'PCA9674')

--- a/host/greatfet/io_expanders/pca9674.py
+++ b/host/greatfet/io_expanders/pca9674.py
@@ -46,12 +46,12 @@ class PCA9674(I2CDevice, DIOExpander):
         super(PCA9674, self).__init__(bus, address, 'PCA9674')
 
     @property
-    def get_number_pins(self):
+    def number_pins(self):
         return 8
 
     def set_direction(self, value):
         # Invert value
-        pin_states = ~value & 2**self.get_number_pins - 1
+        pin_states = ~value & 2**self.number_pins - 1
         self.transmit(pin_states, 0)
 
     def read(self):

--- a/host/greatfet/io_expanders/pca9674.py
+++ b/host/greatfet/io_expanders/pca9674.py
@@ -1,0 +1,61 @@
+# coding: utf-8
+#
+# Copyright (c) 2016 Schuyler St. Leger <schuyler.st.leger@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+from ..io_expander import GreatFETDIOExpander
+from ..peripherals.i2c_device import I2CDevice
+
+class PCA9674(I2CDevice, GreatFETDIOExpander):
+    """PCA9674 I²C I/O expander"""
+
+    def __init__(self, bus, address=0x20):
+        """Initialize a new PCA9674 I²C I/O expander.
+
+        Argsuments:
+            bus: I²C bus the IO PCA9674 is connected to. For a
+                GreatFET One, this would typically be (board.i2c).
+            address: Optional; used to specify a non-default address.
+        """
+
+        super(PCA9674, self).__init__(bus, address, 'PCA9674')
+
+    @property
+    def get_number_pins(self):
+        return 8
+
+    def set_direction(self, value):
+        # Invert value
+        pin_states = ~value & 2**self.get_number_pins - 1
+        self.transmit(pin_states, 0)
+
+    def read(self):
+        return self.transmit([], 1)[0]
+
+    def write(self, value):
+        self.transmit([self._validate_pin_values(value)])

--- a/host/greatfet/io_expanders/pca9674.py
+++ b/host/greatfet/io_expanders/pca9674.py
@@ -28,10 +28,10 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-from ..io_expander import GreatFETDIOExpander
+from ..io_expander import DIOExpander
 from ..peripherals.i2c_device import I2CDevice
 
-class PCA9674(I2CDevice, GreatFETDIOExpander):
+class PCA9674(I2CDevice, DIOExpander):
     """PCA9674 I²C I/O expander"""
 
     def __init__(self, bus, address=0x20):

--- a/host/greatfet/io_expanders/pin.py
+++ b/host/greatfet/io_expanders/pin.py
@@ -1,0 +1,82 @@
+#
+# Copyright (c) 2016 Schuyler St. Leger <schuyler.st.leger@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import print_function
+from ..io_expander import DIOExpander
+
+class PinExpander(DIOExpander):
+    """Example class representing a pin based IO expander"""
+
+    def __init__(self, number_pins=4):
+        super(PinExpander, self).__init__()
+
+        self.__number_pins = int(number_pins)
+        print("Initialized PinExpander")
+
+    @property
+    def number_pins(self):
+        return self.__number_pins
+
+
+    def set_direction(self, directions):
+        super(PinExpander, self).set_direction(directions)
+
+    def set_pin_direction(self, pin_num, direction):
+        pin_num, value = self._validate_pin_args(pin_num, value)
+
+        # Once the direction has been successfully changed on the IO expander,
+        # `_directions` has to be updated.
+        self._directions = self._set_bit(self._directions, pin_num, direction)
+
+        print("Directing PinExpander:  pin: {} direction: {}".format(pin_num, direction))
+
+
+    def read(self):
+        return super(PinExpander, self).read()
+
+    def read_pin(self, pin_num):
+        pin_num = self._validate_pin_number(pin_num)
+
+        pin_value = self._git_bit(self._pins, pin_num)
+        print("Reading PinExpander:  pin: {} value: {}".format(pin_num, pin_value))
+
+        return pin_value
+
+
+    def write(self, value):
+        super(PinExpander, self).write(value)
+
+    def write_pin(self, pin_num, value):
+        pin_num, value = self._validate_pin_args(pin_num, value)
+
+        # Once the value has been successfully sent to the IO expander, `_pins`
+        # has to be updated.
+        self._pins = self._set_bit(self._pins, pin_num, value)
+
+        print("Writing PinExpander:  pin: {} value: {}".format(pin_num, value))

--- a/host/greatfet/io_expanders/port.py
+++ b/host/greatfet/io_expanders/port.py
@@ -1,0 +1,78 @@
+#
+# Copyright (c) 2016 Schuyler St. Leger <schuyler.st.leger@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+from __future__ import print_function
+from ..io_expander import DIOExpander
+
+class PortExpander(DIOExpander):
+    """Example class representing a port based IO expander"""
+
+    def __init__(self, number_pins=4):
+        super(PortExpander, self).__init__()
+
+        self.__number_pins = int(number_pins)
+        print("Initialized PortExpander")
+
+    @property
+    def number_pins(self):
+        return self.__number_pins
+
+
+    def set_direction(self, directions):
+        directions = self._validate_port_value(directions)
+
+        # Once the direction has been successfully changed on the IO expander,
+        # `_directions` has to be updated.
+        self._directions = directions
+
+        print("Directing PortExpander: {0:#0{width}b}".format(directions, width=self.number_pins + 2))
+
+    def set_pin_direction(self, pin_num, direction):
+        super(PortExpander, self).set_pin_direction(pin_num, direction)
+
+
+    def read(self):
+        print("Reading PortExpander: {0:#0{width}b}".format(self._pins, width=self.number_pins + 2))
+        return self._pins
+
+    def read_pin(self, pin_num):
+        return super(PortExpander, self).read_pin(pin_num)
+
+
+    def write(self, value):
+        value = self._validate_port_value(value)
+
+        # Once the value has been successfully sent to the IO expander, `_pins` has to be
+        # updated.
+        self._pins = value
+
+        print("Writing PortExpander: {0:#0{width}b}".format(value, width=self.number_pins + 2))
+
+    def write_pin(self, pin_num, value):
+        super(PortExpander, self).write_pin(pin_num, value)


### PR DESCRIPTION
This adds an API for using IO Expanders and has an implementation for a PCA9674. This also has example implementations for different types hypothetical of IO expanders.