### PR TITLE
Fix issues that prevent USB1 from working.

### DIFF
--- a/firmware/common/greatfet_core.c
+++ b/firmware/common/greatfet_core.c
@@ -40,7 +40,9 @@
 
 #define WAIT_CPU_CLOCK_INIT_DELAY   (10000)
 
+/* USB Target interface */
 static struct gpio_t gpio_usb1_en		= GPIO(2, 8);
+static struct gpio_t gpio_usb1_sense	= GPIO(3, 7);
 
 /* CPLD JTAG interface GPIO pins */
 static struct gpio_t gpio_tdo			= GPIO(5, 18);
@@ -328,11 +330,15 @@ void pin_setup(void) {
 	/* Configure external clock in */
 	scu_pinmux(CLK0, SCU_CONF_FUNCTION1 | SCU_CLK_OUT);
 	
-	/* Enable USB1 controller */
-	SCU_SFSUSB = 0x2;
+	/* Set up the load switch that we'll use if we want to play host on USB1. */
+	/* Default to off, as we don't want to dual-drive VBUS. */
 	scu_pinmux(SCU_PINMUX_USB1_EN, SCU_CONF_FUNCTION0);
 	gpio_output(&gpio_usb1_en);
-	gpio_set(&gpio_usb1_en);
+	gpio_clear(&gpio_usb1_en);
+
+	/* Set up the GPIO we'll be using to sense the presence of USB1 VBUS. */
+	scu_pinmux(SCU_PINMUX_USB1_SENSE, SCU_CONF_FUNCTION0);
+	gpio_input(&gpio_usb1_sense);
 }
 
 void led_on(const led_t led) {

--- a/firmware/greatfet_usb/usb_descriptor.c
+++ b/firmware/greatfet_usb/usb_descriptor.c
@@ -302,13 +302,13 @@ uint8_t usb1_descriptor_string_product[] = {
 	18,						// bLength
 	USB_DESCRIPTOR_TYPE_STRING,		// bDescriptorType
 	'G', 0x00,
-	'r', 0x00,
-	'e', 0x00,
-	'a', 0x00,
-	't', 0x00,
 	'F', 0x00,
-	'E', 0x00,
 	'T', 0x00,
+	'a', 0x00,
+	'r', 0x00,
+	'g', 0x00,
+	'e', 0x00,
+	't', 0x00,
 };
 uint8_t usb1_descriptor_string_serial_number[] = {
 	14,						// bLength


### PR DESCRIPTION
- Correct the time and method of enumerating the FS USB PHY.
- As a temporary hack, lie to the PHY and tell it VBUS is always present.
- Fix an alignment issue on the USB1 endpoint list that broke all transactions.