### PR TITLE
Add flash support for LPC Xplorer

### DIFF
--- a/firmware/common/greatfet_pins.h
+++ b/firmware/common/greatfet_pins.h
@@ -25,6 +25,10 @@
 #include <gpio_lpc.h>
 #include <libopencm3/lpc43xx/scu.h>
 
+#ifndef GREATFET_ONE
+#error greatfet_pins.h included for a non-greatfet board! Use pins.h instead!
+#endif
+
 /*
  * SCU PinMux
  */

--- a/firmware/common/spiflash_target.c
+++ b/firmware/common/spiflash_target.c
@@ -22,7 +22,7 @@
 #include "spiflash.h"
 
 #include <libopencm3/lpc43xx/scu.h>
-#include "greatfet_pins.h"
+#include "pins.h"
 
 /* TODO: Why is SSEL being controlled manually when SSP0 could do it
  * automatically?

--- a/firmware/common/xplorer_pins.h
+++ b/firmware/common/xplorer_pins.h
@@ -90,6 +90,10 @@ static const scu_grp_pin_t pinmux_led[NUM_LEDS] = {
 #define SCU_PINMUX_SGPIO13  (P4_8)
 #define SCU_PINMUX_SGPIO14  (P4_9)
 #define SCU_PINMUX_SGPIO15  (P4_10)
+#define SCU_PINMUX_GPIO5_3  (P2_3)
+#define SCU_PINMUX_GPIO5_5  (P2_5)
+
+
 
 /* SPI flash */
 #define SCU_SSP0_MISO       (P3_6)

--- a/firmware/greatfet_usb/usb_api_spi.c
+++ b/firmware/greatfet_usb/usb_api_spi.c
@@ -27,7 +27,7 @@
 #include <spi_bus.h>
 #include <gpio_lpc.h>
 #include <libopencm3/lpc43xx/scu.h>
-#include <greatfet_pins.h>
+#include <pins.h>
 
 uint8_t spi_buffer[256U];
 /* SSP1 SSEL (CS) pin, used as GPIO so that we control

--- a/host/greatfet/boards/xplorer.py
+++ b/host/greatfet/boards/xplorer.py
@@ -43,3 +43,5 @@ class NXPXplorer(GreatFETBoard):
 
         # Set up the core connection.
         super(NXPXplorer, self).__init__(**device_identifiers)
+
+        self.onboard_flash = SPIFlash(self, device_id=0x15, pages=16384, maximum_address=0x3FFFFF)


### PR DESCRIPTION
The LPC explorer has a different flash, and thus requires a slightly different setup. Also, fixes several places where <greatfet_pins.h> was used instead of <pins.h> and adds a couple of used SCU entries to <xplorer_pins.h> to make things build.