### PR TITLE
Add more detail to the firmware-loading readme.

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,8 +1,11 @@
+#GreatFET Firmware
+
 The primary firmware source code for GreatFET devices is greatfet_usb.  Most
 of the other directories contain firmware source code for test and development.
 The common directory contains source code shared by multiple GreatFET firmware
 projects.
 
+##Building and Installaing to Flash
 
 The firmware is set up for compilation with the GCC toolchain available here:
 
@@ -28,26 +31,63 @@ cd firmware/libopencm3
 make
 ```
 
-To build and install a firmware image for GreatFET:
+To build and install a firmware image for the GreatFET One:
 ```
 cd greatfet_usb
 mkdir build
 cd build
-cmake ..
-make
-greatfet_firmware -w greatfet_usb.bin
+cmake .. -DBOARD=GREATFET_ONE
+make greatfet_usb-flash
 ```
+
+If building for another board, replace ```GREATFET_ONE``` with the the 
+appropriate board string. The following board strings are currently recognized:
+ * ```GREAFET_ONE``` for the GreatFET One
+ * ```NXP_XPLORER``` for the LPC4330 Xplorer.
+
+Reset the device by pressing the RESET button once, and your GreatFET should
+start up running the new firmware. You can check the software version by
+using the greatfet_info tool provided:
+
+```
+# greatfet_info
+Found a GreatFET One!
+  Board ID: 0
+  Firmware version: git-87f4da4
+  Part ID: 300a00a0394358
+  Serial number: 0000000000000000ffffffffffffffff
+```
+
+## DFU Mode: Running from RAM
+
+If your board doesn't currently have GreatFET firmware (e.g. if you built the
+board yourself, or if you're using a NXP Xplorer), or your firmware's in a bad
+state, you can temporarily load firmware into RAM using the LPC4330 DFU
+bootloader. Once the firmware is running, you can then opt to write the firmware
+to flash so will persist across reset.
 
 For loading firmware into RAM with DFU you will also need:
 
 http://dfu-util.gnumonks.org/
 
-To start up GreatFET One in DFU mode, hold down the DFU button while powering it
-on or while pressing and releasing the RESET button.  Release the DFU button
-after the 3V3 LED illuminates.
+Each of the currently supproted boards provides an accessible DFU bootloader:
+ * To start up GreatFET One in DFU mode, hold down the DFU button while powering
+   it on or while pressing and releasing the RESET button.
+ * To start the LPC Xplorer in DFU mode, adjust the J4 switches so SW1-4
+   are OFF, ON, OFF, and ON respectively, and then press the reset button. To
+   resume loading from flash, restore them to so SW1-4 are ON, OFF, OFF, OFF.
 
-A .dfu file is built by default when building firmware.  Alternatively you can
-load a known good .dfu file from a release package with:
+Once the GreatFET is in DFU mode, run the following command from your firmware
+build tree:
 ```
-dfu-util --device 1fc9:000c --alt 0 --download greatfet_usb_ram.dfu
+make greatfet_usb-program
+```
+
+You should see a blinking LED, indicating that the GreatFET firmware is running
+and alive.
+
+If you want to continue to program the flash, you can then issue the "flash"
+command while the firmware is running.
+```
+make greatfet_usb-flash
 ```


### PR DESCRIPTION
Makes the process more clear for programming other boards, as we now apparently have a user trying to use the LPC Xplorer board as a Facedancer:

https://github.com/ktemkin/Facedancer/issues/1