### PR TITLE
Fix showing usage if no args are given

### DIFF
--- a/host/greatfet_firmware
+++ b/host/greatfet_firmware
@@ -97,7 +97,7 @@ def main():
     # Validate our options.
 
     # If we don't have an option, print our usage.
-    if not (args.read, args.write, args.reset):
+    if not any((args.read, args.write, args.reset,)):
         parser.print_help()
         sys.exit(0)
 


### PR DESCRIPTION
The usage message would never be shown because any non-empty tuple is always truthy.