### PR TITLE
Fix missing import for "errno"

### DIFF
--- a/host/greatfet_adc
+++ b/host/greatfet_adc
@@ -31,6 +31,7 @@
 from __future__ import print_function
 
 import argparse
+import errno
 import sys
 import time
 


### PR DESCRIPTION
`errno` [is used](https://github.com/dominicgs/GreatFET-experimental/compare/master...mnaberez:errno?expand=1#diff-aa87df1529eeeb0c137a6d07035e6c18R66) but not imported.