### PR TITLE
Add longopts for all options

### DIFF
--- a/host/greatfet_firmware
+++ b/host/greatfet_firmware
@@ -3,7 +3,7 @@
 # Copyright (c) 2016 Kyle J. Temkin <kyle@ktemkin.com>
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or without 
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #
 # 1. Redistributions of source code must retain the above copyright notice,

--- a/host/greatfet_firmware
+++ b/host/greatfet_firmware
@@ -83,14 +83,15 @@ def main():
     parser.add_argument('-l', '--length', metavar='<n>', type=int,
                         help="number of bytes to read (default: {})".format(MAX_FLASH_LENGTH),
                         default=MAX_FLASH_LENGTH)
-    parser.add_argument('-r', dest='read', metavar='<filename>', type=str,
+    parser.add_argument('-r', '--read', dest='read', metavar='<filename>', type=str,
                         help="Read data into file", default='')
-    parser.add_argument('-w', dest='write', metavar='<filename>', type=str,
+    parser.add_argument('-w', '--write', dest='write', metavar='<filename>', type=str,
                         help="Write data from file", default='')
-    parser.add_argument('-s', dest='serial', metavar='<serialnumber>', type=str,
+    parser.add_argument('-s', '--serial', dest='serial', metavar='<serialnumber>', type=str,
                         help="Serial number of device, if multiple devices", default=None)
-    parser.add_argument('-v', dest='verbose', action='store_true', help="Enable verbose output")
-    parser.add_argument('-R', dest='reset', action='store_true',
+    parser.add_argument('-v', '--verbose', dest='verbose', action='store_true',
+                        help="Enable verbose output")
+    parser.add_argument('-R', '--reset', dest='reset', action='store_true',
                         help="Reset GreatFET after performing other operations.")
     args = parser.parse_args()
 


### PR DESCRIPTION
Only two options had long names defined.  This adds long names for the rest.  `--reset` is especially useful since the short options `-r` (read) and `-R` (reset) may be confused.