### PR TITLE
Hint that new firmware won't run until reset

### DIFF
--- a/host/greatfet_firmware
+++ b/host/greatfet_firmware
@@ -128,6 +128,8 @@ def main():
         log_function("Writing data to SPI flash...")
         spi_flash_write(device, args.write, args.address, log_function)
         log_function("Write complete!")
+        if not args.reset:
+            log_function("Reset not specified; new firmware will not start until next reset.")
 
     # Handle any read commands.
     if args.read:


### PR DESCRIPTION
I flashed custom firmware a few times but my changes didn't take effect.  I then realized that write does not imply reset so the target was still running the old firmware.  This change adds a message to hint that the target may need to be reset.