### PR TITLE
blinky: Use delay() from greatfet_core

### DIFF
--- a/firmware/blinky/blinky.c
+++ b/firmware/blinky/blinky.c
@@ -23,27 +23,22 @@
 
 int main(void)
 {
-	int i;
 	pin_setup();
 
-	/* Blink LED1/2/3 on the board. */
-	while (1) 
+	/* Blink LED1/2/3/4 on the board. */
+	while (1)
 	{
 		led_on(LED1);
 		led_off(LED2);
 		led_on(LED3);
 		led_off(LED4);
+		delay(2000000);
 
-		for (i = 0; i < 2000000; i++)	/* Wait a bit. */
-			__asm__("nop");
-		
 		led_off(LED1);
 		led_on(LED2);
 		led_off(LED3);
 		led_on(LED4);
-		
-		for (i = 0; i < 2000000; i++)	/* Wait a bit. */
-			__asm__("nop");
+		delay(2000000);
 	}
 
 	return 0;


### PR DESCRIPTION
Blinky already uses functions from `greatfet_core` like `led_on()` so use `delay()` from there too.