### PR TITLE
Wrap loose code in main()

### DIFF
--- a/host/greatfet_adc
+++ b/host/greatfet_adc
@@ -40,7 +40,8 @@ from greatfet import GreatFET
 from greatfet.protocol import vendor_requests
 from greatfet.utils import log_silent, log_verbose
 
-if __name__ == '__main__':
+
+def main():
     logfile = 'log.bin'
 #    logfile = '/tmp/fifo'
     # Set up a simple argument parser.
@@ -84,3 +85,8 @@ if __name__ == '__main__':
 
     if not args.adc:
         device.vendor_request_out(vendor_requests.SDIR_RX_STOP)
+
+
+if __name__ == '__main__':
+    main()
+    

--- a/host/greatfet_info
+++ b/host/greatfet_info
@@ -35,8 +35,8 @@ import greatfet
 from greatfet import GreatFET
 from greatfet.protocol import vendor_requests
 
-if __name__ == '__main__':
 
+def main():
     device = GreatFET()
     if not device:
         print('No GreatFET devices found!')
@@ -58,3 +58,7 @@ if __name__ == '__main__':
     #   device.vendor_request_out(vendor_requests.ENABLE_USB1)
     #
     # where ENABLE_USB1 is just an integer constant.
+
+
+if __name__ == '__main__':
+    main()

--- a/host/greatfet_logic
+++ b/host/greatfet_logic
@@ -41,7 +41,7 @@ from greatfet.utils import log_silent, log_verbose
 from greatfet.protocol import vendor_requests
 
 
-if __name__ == '__main__':
+def main():
     logfile = 'log.bin'
     # Set up a simple argument parser.
     parser = argparse.ArgumentParser(description="Utility for flashing the GreatFET's onboard SPI flash")
@@ -77,3 +77,7 @@ if __name__ == '__main__':
         pass
 
     device.vendor_request_out(vendor_requests.LOGIC_ANALYZER_STOP)
+
+
+if __name__ == '__main__':
+    main()

--- a/host/greatfet_sdir
+++ b/host/greatfet_sdir
@@ -41,7 +41,8 @@ from greatfet.protocol import vendor_requests
 from greatfet.utils import log_silent, log_verbose
 import usb
 
-if __name__ == '__main__':
+
+def main():
     logfile = 'log.bin'
 #    logfile = '/tmp/fifo'
     # Set up a simple argument parser.
@@ -104,3 +105,7 @@ if __name__ == '__main__':
             except KeyboardInterrupt:
                 pass
         device.vendor_request_out(vendor_requests.SDIR_TX_STOP)
+
+
+if __name__ == '__main__':
+    main()

--- a/host/greatfet_spiflash
+++ b/host/greatfet_spiflash
@@ -122,7 +122,7 @@ def dump_flash(device, address=None, length=None, filename="flash.bin", log_func
             file.write(data)
             address += 255
 
-def i2c_xfer(device):
+def i2c_xfer(device, log_function):
     log_function("Starting I2C")
     device.vendor_request_out(vendor_requests.I2C_START)
     log_function("I2C started, writing byte")
@@ -132,7 +132,7 @@ def i2c_xfer(device):
     data = device.vendor_request_in(vendor_requests.I2C_RESPONSE, length=3)
     log_function(data)
 
-if __name__ == '__main__':
+def main():
     # Set up a simple argument parser.
     parser = argparse.ArgumentParser(description="Utility for flashing the GreatFET's onboard SPI flash")
     parser.add_argument('-i', '--info', dest='info', action='store_true',
@@ -171,7 +171,11 @@ if __name__ == '__main__':
     device.vendor_request_out(vendor_requests.SPI_INIT)
 
     if args.info:
-        size = spi_info(device, log_function=log_verbose)
+        spi_info(device, log_function=log_verbose)
     if args.dump:
         dump_flash(device, filename=args.dump, address=args.address,
                    length=args.length, log_function=log_verbose)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Replaces:
```
if __name__ == '__main__':
    ... code ...
```
with:
```
def main():
    ... code ...

if __name__ == '__main__':
   main()
```

This will allow the scripts to be eventually called via an [entry point](http://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#the-console-scripts-entry-point).