### PR TITLE
Remove nonfunctional gpio_monitor_mode

### DIFF
--- a/firmware/greatfet_usb/greatfet_usb.c
+++ b/firmware/greatfet_usb/greatfet_usb.c
@@ -121,7 +121,7 @@ usb_request_status_t usb0_vendor_request(
 	usb_endpoint_t* const endpoint,
 	const usb_transfer_stage_t stage) {
 	usb_request_status_t status = USB_REQUEST_STATUS_STALL;
-	
+
 	if( endpoint->setup.request < usb0_vendor_request_handler_count ) {
 		usb_request_handler_fn handler = usb0_vendor_request_handler[endpoint->setup.request];
 		if( handler ) {
@@ -152,15 +152,15 @@ void usb0_configuration_changed(usb_device_t* const device)
 void usb_set_descriptor_by_serial_number(void)
 {
 	iap_cmd_res_t iap_cmd_res;
-	
+
 	/* Read IAP Serial Number Identification */
 	iap_cmd_res.cmd_param.command_code = IAP_CMD_READ_SERIAL_NO;
 	iap_cmd_call(&iap_cmd_res);
-		
+
 	if (iap_cmd_res.status_res.status_ret == CMD_SUCCESS) {
 		usb0_descriptor_string_serial_number[0] = USB_DESCRIPTOR_STRING_SERIAL_BUF_LEN;
 		usb0_descriptor_string_serial_number[1] = USB_DESCRIPTOR_TYPE_STRING;
-		
+
 		/* 32 characters of serial number, convert to UTF-16LE */
 		for (size_t i=0; i<USB_DESCRIPTOR_STRING_SERIAL_LEN; i++) {
 			const uint_fast8_t nibble = (iap_cmd_res.status_res.iap_result[i >> 3] >> (28 - (i & 7) * 4)) & 0xf;
@@ -213,10 +213,8 @@ int main(void) {
 
 	init_usb0();
 	init_greatdancer_api();
-	
+
 	while(true) {
-		if(start_gpio_monitor)
-			gpio_monitor_mode();
 		if(logic_analyzer_enabled) {
 			logic_analyzer_mode();
 		}
@@ -234,6 +232,6 @@ int main(void) {
 		led_toggle(LED1);
 		delay(10000000);
 	}
-	
+
 	return 0;
 }

--- a/firmware/greatfet_usb/usb_api_gpio.c
+++ b/firmware/greatfet_usb/usb_api_gpio.c
@@ -27,7 +27,6 @@
 #include <gpio.h>
 #include <gpio_lpc.h>
 
-volatile bool start_gpio_monitor = false;
 static uint8_t gpio_in_count = 0;
 static uint8_t gpio_out_count = 0;
 static struct gpio_t gpio_in[80];
@@ -56,8 +55,6 @@ usb_request_status_t usb_vendor_request_register_gpio(
 		}
 		led_on(LED2);
 		usb_transfer_schedule_ack(endpoint->in);
-		if(gpio_out_count)
-			start_gpio_monitor = true;
 		led_on(LED3);
 	}
 	return USB_REQUEST_STATUS_OK;
@@ -74,14 +71,4 @@ usb_request_status_t usb_vendor_request_write_gpio(
 		usb_transfer_schedule_ack(endpoint->in);
 	}
 	return USB_REQUEST_STATUS_OK;
-}
-
-void gpio_monitor_mode(void) {
-	led_off(LED4);
-	while(true) {
-		led_off(LED3);
-		delay(10000000);
-		led_on(LED3);
-		delay(10000000);
-	}
 }

--- a/firmware/greatfet_usb/usb_api_gpio.h
+++ b/firmware/greatfet_usb/usb_api_gpio.h
@@ -25,12 +25,9 @@
 #include <usb_type.h>
 #include <usb_request.h>
 
-extern volatile bool start_gpio_monitor;
-
 usb_request_status_t usb_vendor_request_register_gpio(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 usb_request_status_t usb_vendor_request_write_gpio(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
-void gpio_monitor_mode(void);
 
 #endif /* end of include guard: __USB_API_GPIO_H__ */


### PR DESCRIPTION
The `gpio_monitor_mode` task doesn't appear to serve any necessary function anymore but it interferes with the user's ability to control the LEDs.  Let's remove it.