### PR TITLE
Remove LED changes used for debugging

### DIFF
--- a/firmware/greatfet_usb/usb_api_adc.c
+++ b/firmware/greatfet_usb/usb_api_adc.c
@@ -58,7 +58,7 @@ usb_request_status_t usb_vendor_request_read_adc(
 // void adc0_isr(void) {
 // 	unsigned long dummyRead;
 // 	unsigned long ACD0_GDR_Read = ADC0_GDR;
-	
+
 // 	//Extract Conversion Result
 // 	currentResult = (ACD0_GDR_Read>>6) & 0x3FF;
 // 	//Read to Clear Done flag , Also clears AD0 interrupt
@@ -76,21 +76,15 @@ void adc_mode(void) {
 
 
 // vector_table.irq[NVIC_ADC0_IRQ] = adc0_isr;
-led_off(LED1);
-led_off(LED2);
-led_off(LED3);
-led_off(LED4);
 
 	// adc_init(adc_num, pins, clkdiv, clks);
-	
-led_on(LED2);
-	ADC0_CR = ADC_CR_SEL((uint32_t) pins) | 
-	    	ADC_CR_CLKDIV((uint32_t) clkdiv) | 
-	    	ADC_CR_CLKS((uint32_t) clks) | 
+
+	ADC0_CR = ADC_CR_SEL((uint32_t) pins) |
+	    	ADC_CR_CLKDIV((uint32_t) clkdiv) |
+	    	ADC_CR_CLKS((uint32_t) clks) |
 			ADC_CR_PDN;
 	ADC0_CR |= ADC_CR_START(1);
 	while(adc_mode_enabled) {
-led_toggle(LED1);
 		//adc_start(adc_num);
 		// adc_read_to_buffer(adc_num, pins, buf, 10);
 
@@ -104,5 +98,4 @@ led_toggle(LED1);
 				&usb_bulk_buffer[j], BLK_LEN, 0, 0);
 		j = (j+BLK_LEN) % 0x8000;
 	}
-led_off(LED2);
 }

--- a/firmware/greatfet_usb/usb_api_gpio.c
+++ b/firmware/greatfet_usb/usb_api_gpio.c
@@ -53,9 +53,7 @@ usb_request_status_t usb_vendor_request_register_gpio(
 			gpio_set(&gpio_out[gpio_out_count]);
 			gpio_out_count++;
 		}
-		led_on(LED2);
 		usb_transfer_schedule_ack(endpoint->in);
-		led_on(LED3);
 	}
 	return USB_REQUEST_STATUS_OK;
 }

--- a/firmware/greatfet_usb/usb_api_i2c.c
+++ b/firmware/greatfet_usb/usb_api_i2c.c
@@ -66,7 +66,6 @@ usb_request_status_t usb_vendor_request_i2c_xfer(
 		i2c_bus_transfer(&i2c0, endpoint->setup.value & 0xff, i2c_tx_buffer,
 						 endpoint->setup.length, i2c_rx_buffer,
 						 endpoint->setup.index);
-		led_toggle(LED4);
 		usb_transfer_schedule_ack(endpoint->in);
 	}
 	return USB_REQUEST_STATUS_OK;

--- a/firmware/greatfet_usb/usb_api_logic_analyzer.c
+++ b/firmware/greatfet_usb/usb_api_logic_analyzer.c
@@ -60,22 +60,16 @@ static void logic_analyzer_sgpio_stop() {
 }
 
 void logic_analyzer_mode(void) {
-led_off(LED1);
-led_off(LED2);
-led_off(LED3);
-led_off(LED4);
 
 	usb_endpoint_init(&usb0_endpoint_bulk_in);
 
 	logic_analyzer_sgpio_start();
 
-led_on(LED1);
 	unsigned int phase = 0;
 	while(logic_analyzer_enabled) {
 		if ( usb_bulk_buffer_offset >= 16384
 		     && phase == 1) {
-led_on(LED2);
-led_off(LED3);
+
 			usb_transfer_schedule_block(
 				&usb0_endpoint_bulk_in,
 				&usb_bulk_buffer[0x0000],
@@ -87,8 +81,7 @@ led_off(LED3);
 		// Set up IN transfer of buffer 1.
 		if ( usb_bulk_buffer_offset < 16384
 		     && phase == 0) {
-led_on(LED3);
-led_off(LED2);
+
 			usb_transfer_schedule_block(
 				&usb0_endpoint_bulk_in,
 				&usb_bulk_buffer[0x4000],
@@ -97,10 +90,6 @@ led_off(LED2);
 			phase = 1;
 		}
 	}
-led_off(LED1);
-led_off(LED2);
-led_off(LED3);
-led_off(LED4);
 
 	logic_analyzer_sgpio_stop();
 

--- a/firmware/greatfet_usb/usb_api_sdir.c
+++ b/firmware/greatfet_usb/usb_api_sdir.c
@@ -58,7 +58,7 @@ static uint8_t dma_phase;
 
 void sdir_dma_isr() {
 	// gpio_dma_irq_tc_acknowledge();
-	// Experimental 
+	// Experimental
 	GPDMA_INTTCCLEAR = GPDMA_INTTCCLEAR_INTTCCLEAR(0x20);
 	// Switch phase so MCU can do USB things
 	dma_phase = (dma_phase+1) % 4;
@@ -82,7 +82,7 @@ void sdir_tx_stop() {
 }
 
 void setup_tx_pins() {
-	/* GPIO Tx pins */	
+	/* GPIO Tx pins */
 #ifndef NXP_XPLORER
 	int i;
 	scu_pinmux(SCU_PINMUX_GPIO1_0, SCU_GPIO_FAST | SCU_CONF_FUNCTION0);
@@ -175,7 +175,7 @@ void sdir_tx_mode(void) {
 	dma_phase = 0;
 
 	sdir_tx_start();
-led_off(LED3);
+
 	while(sdir_tx_enabled) {
  		// Set up OUT transfer of buffer 0.
  		if (((dma_phase == 2) || (dma_phase == 3)) && usb_phase == 1) {
@@ -195,7 +195,6 @@ led_off(LED3);
  			);
  			usb_phase = 1;
  		}
-		 led_toggle(LED3);
 		//  delay(1000000);
 	}
 	sdir_tx_stop();
@@ -287,7 +286,7 @@ usb_request_status_t usb_vendor_request_sdir_tx_start(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
 	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		tx_samplerate = ((uint32_t)endpoint->setup.value) << 16 
+		tx_samplerate = ((uint32_t)endpoint->setup.value) << 16
 		             | endpoint->setup.index;
 		sdir_tx_enabled = true;
 		usb_transfer_schedule_ack(endpoint->in);

--- a/firmware/greatfet_usb/usb_api_spi.c
+++ b/firmware/greatfet_usb/usb_api_spi.c
@@ -57,7 +57,7 @@ static spiflash_driver_t spi1_target_drv = {
 usb_request_status_t usb_vendor_request_init_spi(
 		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage) {
 	if ((stage == USB_TRANSFER_STAGE_SETUP)) {
-		
+
 		spi_bus_start(spi1_target_drv.target, &ssp1_config_spi);
 		spi1_init(spi1_target_drv.target);
 		usb_transfer_schedule_ack(endpoint->in);
@@ -68,7 +68,7 @@ usb_request_status_t usb_vendor_request_init_spi(
 usb_request_status_t usb_vendor_request_spi_write(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
-	if (stage == USB_TRANSFER_STAGE_SETUP) 
+	if (stage == USB_TRANSFER_STAGE_SETUP)
 	{
 		usb_transfer_schedule_block(endpoint->out, &spi_buffer[0],
 									endpoint->setup.length, NULL, NULL);
@@ -82,7 +82,7 @@ usb_request_status_t usb_vendor_request_spi_write(
 usb_request_status_t usb_vendor_request_spi_read(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
-	if (stage == USB_TRANSFER_STAGE_SETUP) 
+	if (stage == USB_TRANSFER_STAGE_SETUP)
 	{
 		usb_transfer_schedule_block(endpoint->in, &spi_buffer,
 									endpoint->setup.length, NULL, NULL);
@@ -96,7 +96,7 @@ usb_request_status_t usb_vendor_request_spi_dump_flash(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
 	uint32_t addr;
-	if (stage == USB_TRANSFER_STAGE_SETUP) 
+	if (stage == USB_TRANSFER_STAGE_SETUP)
 	{
 		spi1_target_drv.page_len = 256;
 		spi1_target_drv.num_pages = 8192;


### PR DESCRIPTION
Tasks change the LEDs in seemingly random ways, which are probably artifacts from debugging.  In order to allow the user to control the LEDs, tasks shouldn't change them.