### PR TITLE
Move heartbeat to a task that can be started and stopped

### DIFF
--- a/firmware/greatfet_usb/CMakeLists.txt
+++ b/firmware/greatfet_usb/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SRC_M4
 	usb_api_adc.c
 	usb_api_i2c.c
 	usb_api_gpio.c
+	usb_api_heartbeat.c
 	usb_api_logic_analyzer.c
 	usb_api_sdir.c
     usb_api_greatdancer.c

--- a/firmware/greatfet_usb/greatfet_usb.c
+++ b/firmware/greatfet_usb/greatfet_usb.c
@@ -41,6 +41,7 @@
 #include "usb_api_spi.h"
 #include "usb_api_i2c.h"
 #include "usb_api_gpio.h"
+#include "usb_api_heartbeat.h"
 #include "usb_api_logic_analyzer.h"
 #include "usb_api_sdir.h"
 #include "usb_api_greatdancer.h"
@@ -112,6 +113,8 @@ static const usb_request_handler_fn usb0_vendor_request_handler[] = {
   usb_vendor_request_greatdancer_start_nonblocking_read,
   usb_vendor_request_greatdancer_finish_nonblocking_read,
   usb_vendor_request_greatdancer_get_nonblocking_data_length,
+	usb_vendor_request_heartbeat_start,
+	usb_vendor_request_heartbeat_stop,
 };
 
 static const uint32_t usb0_vendor_request_handler_count =
@@ -227,10 +230,9 @@ int main(void) {
 		if(adc_mode_enabled) {
 			adc_mode();
 		}
-
-		/* Blink LED1 to let us know we're alive */
-		led_toggle(LED1);
-		delay(10000000);
+		if(heartbeat_mode_enabled) {
+			heartbeat_mode();
+		}
 	}
 
 	return 0;

--- a/firmware/greatfet_usb/usb_api_heartbeat.c
+++ b/firmware/greatfet_usb/usb_api_heartbeat.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Mike Naberezny <mike@naberezny.com>
+ *
+ * This file is part of GreatFET.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "usb_api_heartbeat.h"
+
+#include "usb.h"
+#include "usb_queue.h"
+#include "usb_endpoint.h"
+
+volatile bool heartbeat_mode_enabled = true;
+
+void heartbeat_mode(void) {
+  led_toggle(HEARTBEAT_LED);
+  delay(10000000); // TODO this should be made to be nonblocking
+}
+
+usb_request_status_t usb_vendor_request_heartbeat_start(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
+{
+	if (stage == USB_TRANSFER_STAGE_SETUP) {
+		heartbeat_mode_enabled = true;
+    led_off(HEARTBEAT_LED);
+		usb_transfer_schedule_ack(endpoint->in);
+	}
+	return USB_REQUEST_STATUS_OK;
+}
+
+usb_request_status_t usb_vendor_request_heartbeat_stop(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
+{
+	if (stage == USB_TRANSFER_STAGE_SETUP) {
+		heartbeat_mode_enabled = false;
+    led_off(HEARTBEAT_LED);
+		usb_transfer_schedule_ack(endpoint->in);
+	}
+	return USB_REQUEST_STATUS_OK;
+}

--- a/firmware/greatfet_usb/usb_api_heartbeat.h
+++ b/firmware/greatfet_usb/usb_api_heartbeat.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Mike Naberezny <mike@naberezny.com>
+ *
+ * This file is part of GreatFET.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __USB_API_HEARTBEAT_H__
+#define __USB_API_HEARTBEAT_H__
+
+#include <greatfet_core.h>
+#include <usb_type.h>
+#include <usb_request.h>
+
+#define HEARTBEAT_LED LED1
+
+extern volatile bool heartbeat_mode_enabled;
+
+usb_request_status_t usb_vendor_request_heartbeat_start(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
+usb_request_status_t usb_vendor_request_heartbeat_stop(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
+
+void heartbeat_mode(void);
+
+#endif /*__USB_API_HEARTBEAT_H__*/

--- a/host/greatfet/protocol/vendor_requests.py
+++ b/host/greatfet/protocol/vendor_requests.py
@@ -38,7 +38,7 @@ Ideally we'll add an offset (100?) to per-board vendor requests to separate
 requests that may differ from base-board to base-board.
 """
 
-requests = [
+requests = (
     # Internal programming requests.
     'INIT_SPIFLASH',
     'WRITE_SPIFLASH',
@@ -94,12 +94,14 @@ requests = [
     'GREATDANCER_CLEAN_UP_TRANSFER',
     'GREATDANCER_START_NONBLOCKING_READ',
     'GREATDANCER_FINISH_NONBLOCKING_READ',
-    'GREATDANCER_GET_NONBLOCKING_LENGTH'
-]
+    'GREATDANCER_GET_NONBLOCKING_LENGTH',
 
-# Get a reference (as an object) to this module (self)
-this_module = globals()
+    'HEARTBEAT_START',
+    'HEARTBEAT_STOP',
+)
 
-for i in range(len(requests)):
-    this_module[requests[i]] = i
-
+def _create_module_level_constants():
+    this_module = globals()
+    for i, name in enumerate(this_module['requests']):
+        this_module[name] = i
+_create_module_level_constants()


### PR DESCRIPTION
This change moves the heartbeat LED blink code into a task that can be started/stopped using vendor requests.  The task is running by default.

```
>>> from greatfet import GreatFET
>>> from greatfet.protocol import vendor_requests
>>> device = GreatFET()
>>> device.vendor_request_out(vendor_requests.HEARTBEAT_STOP)
0
>>> device.vendor_request_out(vendor_requests.HEARTBEAT_START)
0
```

The use case for this change is to allow the user to control all of the onboard LEDs.  Currently, the heartbeat code always has control of LED1.