### PR TITLE
Move LED request handler to its own file

### DIFF
--- a/firmware/greatfet_usb/CMakeLists.txt
+++ b/firmware/greatfet_usb/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SRC_M4
 	usb_api_adc.c
 	usb_api_i2c.c
 	usb_api_gpio.c
+  usb_api_leds.c
 	usb_api_heartbeat.c
 	usb_api_logic_analyzer.c
 	usb_api_sdir.c

--- a/firmware/greatfet_usb/greatfet_usb.c
+++ b/firmware/greatfet_usb/greatfet_usb.c
@@ -41,34 +41,12 @@
 #include "usb_api_spi.h"
 #include "usb_api_i2c.h"
 #include "usb_api_gpio.h"
+#include "usb_api_leds.h"
 #include "usb_api_heartbeat.h"
 #include "usb_api_logic_analyzer.h"
 #include "usb_api_sdir.h"
 #include "usb_api_greatdancer.h"
 #include "usb_bulk_buffer.h"
-
-usb_request_status_t usb_vendor_request_led_toggle(
-		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
-{
-	if (stage == USB_TRANSFER_STAGE_SETUP) {
-		switch(endpoint->setup.value) {
-			case 1:
-				led_toggle(LED1);
-				break;
-			case 2:
-				led_toggle(LED2);
-				break;
-			case 3:
-				led_toggle(LED3);
-				break;
-			case 4:
-				led_toggle(LED4);
-				break;
-		}
-		usb_transfer_schedule_ack(endpoint->in);
-	}
-	return USB_REQUEST_STATUS_OK;
-}
 
 static const usb_request_handler_fn usb0_vendor_request_handler[] = {
 	usb_vendor_request_init_spiflash,

--- a/firmware/greatfet_usb/usb_api_leds.c
+++ b/firmware/greatfet_usb/usb_api_leds.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Dominic Spill <dominicgs@gmail.com>
+ * Copyright 2017 Mike Naberezny <mike@naberezny.com>
+ *
+ * This file is part of GreatFET.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "usb_api_leds.h"
+
+#include "usb.h"
+#include "usb_queue.h"
+#include "usb_endpoint.h"
+
+usb_request_status_t usb_vendor_request_led_toggle(
+		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
+{
+	if (stage == USB_TRANSFER_STAGE_SETUP) {
+		switch(endpoint->setup.value) {
+			case 1:
+				led_toggle(LED1);
+				break;
+			case 2:
+				led_toggle(LED2);
+				break;
+			case 3:
+				led_toggle(LED3);
+				break;
+			case 4:
+				led_toggle(LED4);
+				break;
+		}
+		usb_transfer_schedule_ack(endpoint->in);
+	}
+	return USB_REQUEST_STATUS_OK;
+}

--- a/firmware/greatfet_usb/usb_api_leds.h
+++ b/firmware/greatfet_usb/usb_api_leds.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2015 Dominic Spill <dominicgs@gmail.com>
+ * Copyright 2017 Mike Naberezny <mike@naberezny.com>
+ *
+ * This file is part of GreatFET.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+ #ifndef __USB_API_LEDS_H__
+ #define __USB_API_LEDS_H__
+
+ #include <greatfet_core.h>
+ #include <usb_type.h>
+ #include <usb_request.h>
+
+ usb_request_status_t usb_vendor_request_led_toggle(
+ 		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
+
+ #endif /*__USB_API_LEDS_H__*/


### PR DESCRIPTION
Move `usb_vendor_request_led_toggle()` to a separate `usb_api_` file for parity with the other USB request handlers.