### PR TITLE
Add debug functions to send messages out UART2

### DIFF
--- a/firmware/common/debug.c
+++ b/firmware/common/debug.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Dominic Spill <dominicgs@gmail.com>
+ * Copyright 2017 Mike Naberezny <mike@naberezny.com>
+ *
+ * This file is part of GreatFET.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <pins.h>
+#include <libopencm3/lpc43xx/scu.h>
+#include <libopencm3/lpc43xx/uart.h>
+#include "debug.h"
+
+void debug_init(void) {
+	// UART2 TX on P7_1
+	scu_pinmux(SCU_PINMUX_GPIO3_9, SCU_UART_RX_TX | SCU_CONF_FUNCTION6);
+	// UART2 RX on P7_2
+	scu_pinmux(SCU_PINMUX_GPIO3_10, SCU_UART_RX_TX | SCU_CONF_FUNCTION6);
+	// 9600-N-8-1
+  uart_init(UART2, UART_DATABIT_8, UART_STOPBIT_1, UART_PARITY_NONE,
+              /* uart_divisor */   1328,
+              /* uart_divaddval */ 0,
+              /* uart_mulval */    1);
+}
+
+void debug_log(char *str) {
+  while (*str != '\0')
+  {
+    uart_write(UART2, *str);
+    str++;
+  }
+}

--- a/firmware/common/debug.h
+++ b/firmware/common/debug.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Dominic Spill <dominicgs@gmail.com>
+ * Copyright 2017 Mike Naberezny <mike@naberezny.com>
+ *
+ * This file is part of GreatFET.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/* Initialize UART2 for debug logging */
+void debug_init(void);
+
+/* Log text to UART2 */
+void debug_log(char *str);

--- a/firmware/greatfet_usb/CMakeLists.txt
+++ b/firmware/greatfet_usb/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SRC_M4
 	"${PATH_GREATFET_FIRMWARE_COMMON}/fault_handler.c"
 	"${PATH_GREATFET_FIRMWARE_COMMON}/rom_iap.c"
 	"${PATH_GREATFET_FIRMWARE_COMMON}/spi_bus.c"
+	"${PATH_GREATFET_FIRMWARE_COMMON}/debug.c"
 )
 
 DeclareTargets()


### PR DESCRIPTION
This patch resurrects 8d29f4446b9330da0a059a3145514e3809b6b59e with some changes to the UART settings and API.  It allows logging debug messages out UART2 like this:

```
// 9600-N-8-1, TX on P7_1, RX on P7_2
debug_init();

debug_log("foo\n");
debug_log("bar\n");
```

I've tested this using an FTDI [TTL-232R-3V3](https://www.digikey.com/product-detail/en/ftdi-future-technology-devices-international-ltd/TTL-232R-3V3/768-1015-ND/1836393) under Linux with minicom and it worked fine.  This patch is transmit-only but I've also tested [`uart_read`](https://github.com/dominicgs/libopencm3/blob/1c45abedbce49fe179030287325baf91f7e0d5e1/lib/lpc43xx/uart.c#L182) and receive worked also.