### PR TITLE
Make heartbeat nonblocking by polling RTC

### DIFF
--- a/firmware/common/greatfet_core.c
+++ b/firmware/common/greatfet_core.c
@@ -29,7 +29,9 @@
 #include "spiflash_target.h"
 #include "i2c_bus.h"
 #include "i2c_lpc.h"
+#include <libopencm3/lpc43xx/creg.h>
 #include <libopencm3/lpc43xx/cgu.h>
+#include <libopencm3/lpc43xx/rtc.h>
 #include <libopencm3/lpc43xx/scu.h>
 #include <libopencm3/lpc43xx/ssp.h>
 
@@ -299,6 +301,21 @@ void cpu_clock_pll1_max_speed(void)
 	/* wait until stable */
 	while (!(CGU_PLL1_STAT & CGU_PLL1_STAT_LOCK_MASK));
 
+}
+
+void rtc_init(void) {
+		/* Enable power to 32 KHz oscillator */
+		CREG_CREG0 &= ~CREG_CREG0_PD32KHZ;
+		/* Release 32 KHz oscillator reset */
+		CREG_CREG0 &= ~CREG_CREG0_RESET32KHZ;
+		/* Enable 1 KHz output (required per LPC43xx user manual section 37.2) */
+		CREG_CREG0 |= CREG_CREG0_EN1KHZ;
+		/* Release CTC Reset */
+		RTC_CCR &= ~RTC_CCR_CTCRST(1);
+		/* Disable calibration counter */
+		RTC_CCR &= ~RTC_CCR_CCALEN(1);
+		/* Enable clock */
+		RTC_CCR |= RTC_CCR_CLKEN(1);
 }
 
 void pin_setup(void) {

--- a/firmware/common/greatfet_core.h
+++ b/firmware/common/greatfet_core.h
@@ -69,6 +69,8 @@ void cpu_clock_init(void);
 void cpu_clock_pll1_low_speed(void);
 void cpu_clock_pll1_max_speed(void);
 
+void rtc_init(void);
+
 void pin_setup(void);
 
 void enable_1v8_power(void);

--- a/firmware/greatfet_usb/greatfet_usb.c
+++ b/firmware/greatfet_usb/greatfet_usb.c
@@ -188,6 +188,7 @@ void init_usb0(void) {
 int main(void) {
 	pin_setup();
 	cpu_clock_init();
+	rtc_init();
 
 	init_usb0();
 	init_greatdancer_api();


### PR DESCRIPTION
The GreatFET firmware sits in a [busy loop](https://github.com/dominicgs/GreatFET-experimental/blob/e390a01bd1776394987ab401a31a3c0dfc8e5d0c/firmware/greatfet_usb/usb_api_heartbeat.c#L31-L32
) for 1 second on every iteration of the main loop so it can blink the heartbeat LED.  No meaningful processing can be done in the main loop (e.g. servicing a queue filled by an ISR) because the main loop blocks for so long doing nothing.

This change replaces the busy loop with polling the RTC seconds register.  The heartbeat LED blinks as before but it doesn't block the main loop.  Polling is used instead of an ISR so that the LED will stop blinking if the main loop gets stuck, as it did before, which is useful for debugging.