### PR TITLE
Always run PLL1 at max speed

### DIFF
--- a/firmware/common/debug.c
+++ b/firmware/common/debug.c
@@ -31,6 +31,8 @@ void debug_init(void) {
 	// UART2 RX on P7_2
 	scu_pinmux(SCU_PINMUX_GPIO3_10, SCU_UART_RX_TX | SCU_CONF_FUNCTION6);
 	// 9600-N-8-1
+	// Note: UART clock is derived from PLL1; these settings assume that PLL1
+	// has been set to maximum (204 MHz) by calling cpu_clock_pll1_max_speed()
   uart_init(UART2, UART_DATABIT_8, UART_STOPBIT_1, UART_PARITY_NONE,
               /* uart_divisor */   1328,
               /* uart_divaddval */ 0,

--- a/firmware/greatfet_usb/greatfet_usb.c
+++ b/firmware/greatfet_usb/greatfet_usb.c
@@ -120,16 +120,6 @@ const usb_request_handlers_t usb0_request_handlers = {
 };
 
 
-void usb0_configuration_changed(usb_device_t* const device)
-{
-	if( device->configuration->number == 1 ) {
-		cpu_clock_pll1_max_speed();
-	} else {
-		/* Configuration number equal 0 means usb bus reset. */
-		cpu_clock_pll1_low_speed();
-	}
-}
-
 void usb_set_descriptor_by_serial_number(void)
 {
 	iap_cmd_res_t iap_cmd_res;
@@ -163,9 +153,6 @@ void usb_set_descriptor_by_serial_number(void)
 
 void init_usb0(void) {
 	usb_set_descriptor_by_serial_number();
-
-	usb_set_configuration_changed_cb(usb0_configuration_changed);
-
 	usb_peripheral_reset(&usb_devices[0]);
 	usb_device_init(&usb_devices[0]);
 
@@ -186,8 +173,9 @@ void init_usb0(void) {
 
 
 int main(void) {
-	pin_setup();
 	cpu_clock_init();
+	cpu_clock_pll1_max_speed();
+	pin_setup();
 	rtc_init();
 
 	init_usb0();


### PR DESCRIPTION
GreatFET starts up in with PLL1 in low speed and then switches to high speed after USB enumeration completes.  The libopencm3 functions set up the UART clock to be derived from PLL1, and the [debug UART functions](https://github.com/dominicgs/GreatFET-experimental/blob/3b0a3f171af7bcecaa4a6401ecdd194afdfc7e55/firmware/common/debug.c#L34-L37) assumes PLL1 is high speed.  If you use the debug UART functions before USB is ready, the UART output will be garbled because the settings are wrong for PLL1 low speed.  This change leaves PLL1 in high speed mode all the time to fix this.