### PR TITLE
Remove HackRF 1.8v control artifacts

### DIFF
--- a/firmware/common/greatfet_core.h
+++ b/firmware/common/greatfet_core.h
@@ -73,9 +73,6 @@ void rtc_init(void);
 
 void pin_setup(void);
 
-void enable_1v8_power(void);
-void disable_1v8_power(void);
-
 typedef enum {
 	LED1 = 0,
 	LED2 = 1,


### PR DESCRIPTION
```
$ grep -r 1v8 *
firmware/common/greatfet_core.h:void enable_1v8_power(void);
firmware/common/greatfet_core.h:void disable_1v8_power(void);
$
```
These declarations are [leftovers from HackRF](https://github.com/mossmann/hackrf/blob/44333b76359de2856de9eca4052758eb733ab085/firmware/common/hackrf_core.c#L843-L849).