### PR TITLE
Initialize clock during Blinky setup

### DIFF
--- a/firmware/blinky/blinky.c
+++ b/firmware/blinky/blinky.c
@@ -23,6 +23,9 @@
 
 int main(void)
 {
+	cpu_clock_init();
+	cpu_clock_pll1_max_speed();
+	rtc_init();
 	pin_setup();
 
 	/* Blink LED1/2/3/4 on the board. */
@@ -32,13 +35,13 @@ int main(void)
 		led_off(LED2);
 		led_on(LED3);
 		led_off(LED4);
-		delay(2000000);
+		delay(5000000);
 
 		led_off(LED1);
 		led_on(LED2);
 		led_off(LED3);
 		led_on(LED4);
-		delay(2000000);
+		delay(5000000);
 	}
 
 	return 0;


### PR DESCRIPTION
Developers will probably use Blinky as the starting point for writing their first GreatFET firmware.  Some core functions [like debug](https://github.com/dominicgs/GreatFET-experimental/blob/16c66249648f2762669fce72069fbd0a9f240ddd/firmware/common/debug.c#L34-L39) depend on PLL1 being set to max speed.  This patch adds that setup to Blinky to avoid confusion when developers try to use `debug_log()` and similar functions that depend on specific PLL1 settings.