### PR TITLE
Fix GPIO pin directions not being configured

### DIFF
--- a/firmware/greatfet_usb/usb_api_gpio.c
+++ b/firmware/greatfet_usb/usb_api_gpio.c
@@ -61,7 +61,8 @@ usb_request_status_t usb_vendor_request_register_gpio(
 					 (gpio_params[i] >> 8) & 0xFF, /* port */
 					  gpio_params[i] & 0xFF		     /* pin */
 					);
-			gpio_set(&gpio_in[gpio_in_count]);
+			gpio_input(&gpio_in[gpio_in_count]);
+			/* TODO scu pinmux must be configured to make pin gpio */
 			gpio_in_count++;
 		}
 
@@ -71,7 +72,9 @@ usb_request_status_t usb_vendor_request_register_gpio(
 					 (gpio_params[i]>>8) & 0xFF, /* port */
 					  gpio_params[i] & 0xFF		   /* pin */
 					);
-			gpio_set(&gpio_out[gpio_out_count]);
+			gpio_output(&gpio_out[gpio_out_count]);
+			gpio_clear(&gpio_out[gpio_out_count]);
+			/* TODO scu pinmux must be configured to make pin gpio */
 			gpio_out_count++;
 		}
 

--- a/host/greatfet/peripherals/gpio.py
+++ b/host/greatfet/peripherals/gpio.py
@@ -33,7 +33,7 @@ GPIO pins
 
 def _gpio(port, pin):
     """Pack an LPC GPIO port and pin into a 16-bit number for USB transfers"""
-    return (port << 8) + pin;
+    return (port << 8) + pin
 
 class J1(object):
     """GreatFET One header J1 pins and their LPC GPIO equivalents"""


### PR DESCRIPTION
This patch fixes `usb_vendor_request_register_gpio()` so that the pin directions can be configured.  It also adds comments to explain the packet format since there is no host code yet to demonstrate it.