### PR TITLE
Use a common "SPIFLASH_" prefix for flash vendor requests

### DIFF
--- a/firmware/greatfet_usb/greatfet_usb.c
+++ b/firmware/greatfet_usb/greatfet_usb.c
@@ -49,10 +49,10 @@
 #include "usb_bulk_buffer.h"
 
 static const usb_request_handler_fn usb0_vendor_request_handler[] = {
-	usb_vendor_request_init_spiflash,
-	usb_vendor_request_write_spiflash,
-	usb_vendor_request_read_spiflash,
-	usb_vendor_request_erase_spiflash,
+	usb_vendor_request_spiflash_init,
+	usb_vendor_request_spiflash_write,
+	usb_vendor_request_spiflash_read,
+	usb_vendor_request_spiflash_erase,
 	usb_vendor_request_read_board_id,
 	usb_vendor_request_read_version_string,
 	usb_vendor_request_read_partid_serialno,

--- a/firmware/greatfet_usb/usb_api_spiflash.c
+++ b/firmware/greatfet_usb/usb_api_spiflash.c
@@ -58,11 +58,11 @@ struct flash_params {
 	uint32_t num_bytes;
 	uint16_t gpio_select;
 	uint8_t device_id;
-	
+
 };
 struct flash_params params;
 
-usb_request_status_t usb_vendor_request_init_spiflash(
+usb_request_status_t usb_vendor_request_spiflash_init(
 		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage) {
 	if ((stage == USB_TRANSFER_STAGE_SETUP) &&
 		(endpoint->setup.length == 11)) {
@@ -76,7 +76,7 @@ usb_request_status_t usb_vendor_request_init_spiflash(
 		spi_flash_drv.device_id = params.device_id;
 		// Can't use the GPIO() define as the struct alreay exists
 		GPIO_SET(gpio_spiflash_select, (params.gpio_select>>8)&0xFF, params.gpio_select&0xFF);
-		
+
 		spi_target.gpio_select = &gpio_spiflash_select;
 		spi_bus_start(spi_flash_drv.target, &ssp_config_spi);
 		spiflash_setup(&spi_flash_drv);
@@ -84,8 +84,8 @@ usb_request_status_t usb_vendor_request_init_spiflash(
 	}
 	return USB_REQUEST_STATUS_OK;
 }
-	
-usb_request_status_t usb_vendor_request_erase_spiflash(
+
+usb_request_status_t usb_vendor_request_spiflash_erase(
 		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage) {
 		if (stage == USB_TRANSFER_STAGE_SETUP) {
 			/* only chip erase is implemented */
@@ -95,7 +95,7 @@ usb_request_status_t usb_vendor_request_erase_spiflash(
 	return USB_REQUEST_STATUS_OK;
 }
 
-usb_request_status_t usb_vendor_request_write_spiflash(
+usb_request_status_t usb_vendor_request_spiflash_write(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
 	uint32_t addr = 0;
@@ -131,13 +131,13 @@ usb_request_status_t usb_vendor_request_write_spiflash(
 	}
 }
 
-usb_request_status_t usb_vendor_request_read_spiflash(
+usb_request_status_t usb_vendor_request_spiflash_read(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
 {
 	uint32_t addr;
 	uint16_t len;
 
-	if (stage == USB_TRANSFER_STAGE_SETUP) 
+	if (stage == USB_TRANSFER_STAGE_SETUP)
 	{
 		addr = (endpoint->setup.value << 16) | endpoint->setup.index;
 		len = endpoint->setup.length;
@@ -150,13 +150,13 @@ usb_request_status_t usb_vendor_request_read_spiflash(
 						    NULL, NULL);
 			return USB_REQUEST_STATUS_OK;
 		}
-	} else if (stage == USB_TRANSFER_STAGE_DATA) 
+	} else if (stage == USB_TRANSFER_STAGE_DATA)
 	{
 			addr = (endpoint->setup.value << 16) | endpoint->setup.index;
 			len = endpoint->setup.length;
 			/* This check is redundant but makes me feel better. */
 			if ((len > spi_flash_drv.page_len) || (addr > spi_flash_drv.num_bytes)
-					|| ((addr + len) > spi_flash_drv.num_bytes)) 
+					|| ((addr + len) > spi_flash_drv.num_bytes))
 			{
 				return USB_REQUEST_STATUS_STALL;
 			} else
@@ -164,9 +164,8 @@ usb_request_status_t usb_vendor_request_read_spiflash(
 				usb_transfer_schedule_ack(endpoint->out);
 				return USB_REQUEST_STATUS_OK;
 			}
-	} else 
+	} else
 	{
 		return USB_REQUEST_STATUS_OK;
 	}
 }
-

--- a/firmware/greatfet_usb/usb_api_spiflash.h
+++ b/firmware/greatfet_usb/usb_api_spiflash.h
@@ -26,13 +26,13 @@
 #include <usb_type.h>
 #include <usb_request.h>
 
-usb_request_status_t usb_vendor_request_init_spiflash(
+usb_request_status_t usb_vendor_request_spiflash_init(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
-usb_request_status_t usb_vendor_request_erase_spiflash(
+usb_request_status_t usb_vendor_request_spiflash_erase(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
-usb_request_status_t usb_vendor_request_write_spiflash(
+usb_request_status_t usb_vendor_request_spiflash_write(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
-usb_request_status_t usb_vendor_request_read_spiflash(
+usb_request_status_t usb_vendor_request_spiflash_read(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 
 #endif /* end of include guard: __USB_API_SPIFLASH_H__ */

--- a/host/greatfet/peripherals/spi_flash.py
+++ b/host/greatfet/peripherals/spi_flash.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2016 Kyle J. Temkin <kyle@ktemkin.com>
 # All rights reserved.
 #
-# Redistribution and use in source and binary forms, with or without 
+# Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #
 # 1. Redistributions of source code must retain the above copyright notice,
@@ -62,7 +62,7 @@ class SPIFlash(GreatFETPeripheral):
 
         data = struct.pack("<HHIHB", page_size, pages, page_size*pages,
                            chip_select, device_id)
-        result = self.board.vendor_request_out(vendor_requests.INIT_SPIFLASH,
+        result = self.board.vendor_request_out(vendor_requests.SPIFLASH_INIT,
             value=0, index=0, data=data, timeout=1000)
 
         if result < 0:
@@ -75,7 +75,7 @@ class SPIFlash(GreatFETPeripheral):
         CAUTION: After running this function, you'll need to use DFU mode to
         load a new GreatFET program onto the board. Be careful!
         """
-        result = self.board.vendor_request_out(vendor_requests.ERASE_SPIFLASH)
+        result = self.board.vendor_request_out(vendor_requests.SPIFLASH_ERASE)
 
         if result:
             raise errors.from_greatfet_error(result)
@@ -234,7 +234,7 @@ class SPIFlash(GreatFETPeripheral):
 
         # Perform the actual write. Note that this may take time, as we have to
         # wait for the flash chip to perform the write.
-        result = self.board.vendor_request_out(vendor_requests.WRITE_SPIFLASH,
+        result = self.board.vendor_request_out(vendor_requests.SPIFLASH_WRITE,
             value=address_high, index=address_low, data=data_array, timeout=0)
 
         if result < 0:
@@ -266,10 +266,7 @@ class SPIFlash(GreatFETPeripheral):
         address_low = address & 0xFFFF;
 
         # Perform the actual read.
-        result = self.board.vendor_request_in(vendor_requests.READ_SPIFLASH,
+        result = self.board.vendor_request_in(vendor_requests.SPIFLASH_READ,
             value=address_high, index=address_low, length=length)
 
         return result
-
-
-

--- a/host/greatfet/protocol/vendor_requests.py
+++ b/host/greatfet/protocol/vendor_requests.py
@@ -40,10 +40,10 @@ requests that may differ from base-board to base-board.
 
 requests = (
     # Internal programming requests.
-    'INIT_SPIFLASH',
-    'WRITE_SPIFLASH',
-    'READ_SPIFLASH',
-    'ERASE_SPIFLASH',
+    'SPIFLASH_INIT',
+    'SPIFLASH_WRITE',
+    'SPIFLASH_READ',
+    'SPIFLASH_ERASE',
 
     # Board information API.
     'READ_BOARD_ID',


### PR DESCRIPTION
Consistency with other vendor request groups (cf. `I2C_`, `SPI_`, `ADC_`, `SDIR_`, `GREATDANCER_`, etc).