### PR TITLE
Add vendor request to clear GPIO registrations

### DIFF
--- a/firmware/greatfet_usb/greatfet_usb.c
+++ b/firmware/greatfet_usb/greatfet_usb.c
@@ -93,6 +93,7 @@ static const usb_request_handler_fn usb0_vendor_request_handler[] = {
   usb_vendor_request_greatdancer_get_nonblocking_data_length,
 	usb_vendor_request_heartbeat_start,
 	usb_vendor_request_heartbeat_stop,
+	usb_vendor_request_gpio_reset,
 };
 
 static const uint32_t usb0_vendor_request_handler_count =

--- a/firmware/greatfet_usb/usb_api_gpio.c
+++ b/firmware/greatfet_usb/usb_api_gpio.c
@@ -120,3 +120,27 @@ usb_request_status_t usb_vendor_request_gpio_write(
 	}
 	return USB_REQUEST_STATUS_OK;
 }
+
+/* Reset any registered GPIO pins back to their default state and
+ * clear all registrations.
+ */
+usb_request_status_t usb_vendor_request_gpio_reset(
+		usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage)
+{
+	uint8_t i;
+
+	if (stage == USB_TRANSFER_STAGE_SETUP) {
+		/* change any outputs back to inputs */
+		for (i=0; i<gpio_out_count; i++) {
+			gpio_input(&gpio_out[i]);
+		}
+
+		/* unregister all */
+		gpio_in_count = 0;
+		gpio_out_count = 0;
+
+		usb_transfer_schedule_ack(endpoint->in);
+	}
+
+	return USB_REQUEST_STATUS_OK;
+}

--- a/firmware/greatfet_usb/usb_api_gpio.h
+++ b/firmware/greatfet_usb/usb_api_gpio.h
@@ -29,5 +29,7 @@ usb_request_status_t usb_vendor_request_gpio_register(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 usb_request_status_t usb_vendor_request_gpio_write(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
+usb_request_status_t usb_vendor_request_gpio_reset(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 
 #endif /* end of include guard: __USB_API_GPIO_H__ */

--- a/host/greatfet/protocol/vendor_requests.py
+++ b/host/greatfet/protocol/vendor_requests.py
@@ -98,6 +98,8 @@ requests = (
 
     'HEARTBEAT_START',
     'HEARTBEAT_STOP',
+
+    'GPIO_RESET',
 )
 
 def _create_module_level_constants():


### PR DESCRIPTION
Currently, there is no way for the host to interrogate previous GPIO registrations that have been made.  Until that is implemented, provide a way to reset the registrations as a way for the host to resynchronize with the state of the GreatFET.