### PR TITLE
Add vendor request to read GPIO inputs

### DIFF
--- a/firmware/greatfet_usb/greatfet_usb.c
+++ b/firmware/greatfet_usb/greatfet_usb.c
@@ -94,6 +94,7 @@ static const usb_request_handler_fn usb0_vendor_request_handler[] = {
 	usb_vendor_request_heartbeat_start,
 	usb_vendor_request_heartbeat_stop,
 	usb_vendor_request_gpio_reset,
+	usb_vendor_request_gpio_read,
 };
 
 static const uint32_t usb0_vendor_request_handler_count =

--- a/firmware/greatfet_usb/usb_api_gpio.h
+++ b/firmware/greatfet_usb/usb_api_gpio.h
@@ -29,6 +29,8 @@ usb_request_status_t usb_vendor_request_gpio_register(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 usb_request_status_t usb_vendor_request_gpio_write(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
+usb_request_status_t usb_vendor_request_gpio_read(
+	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 usb_request_status_t usb_vendor_request_gpio_reset(
 	usb_endpoint_t* const endpoint, const usb_transfer_stage_t stage);
 

--- a/host/greatfet/protocol/vendor_requests.py
+++ b/host/greatfet/protocol/vendor_requests.py
@@ -100,6 +100,7 @@ requests = (
     'HEARTBEAT_STOP',
 
     'GPIO_RESET',
+    'GPIO_READ',
 )
 
 def _create_module_level_constants():


### PR DESCRIPTION
This change adds a new vendor request so the host can read GPIO lines that have been registered as inputs.  It always returns the state of all inputs.  Each GPIO input line is one bit, so the data packet contains one byte for every eight GPIO inputs.