### PR TITLE
Add support for controlling GPIO from host code

### DIFF
--- a/host/greatfet/boards/one.py
+++ b/host/greatfet/boards/one.py
@@ -28,9 +28,10 @@
 #
 
 from ..board import GreatFETBoard
-from ..peripherals.spi_flash import SPIFlash
+from ..peripherals.gpio import GPIO
 from ..peripherals.i2c_bus import I2CBus
 from ..peripherals.spi_bus import SPIBus
+from ..peripherals.spi_flash import SPIFlash
 
 
 class GreatFETOne(GreatFETBoard):
@@ -58,3 +59,5 @@ class GreatFETOne(GreatFETBoard):
         # hacking/experimentation.
         self.i2c = self.i2c_busses[0]
         self.spi = self.spi_busses[0]
+
+        self.gpio = GPIO(self)


### PR DESCRIPTION
#### Overview

This adds new functions to the host code so individual GPIO lines can be controlled.

#### Examples 

Toggle output `J1.P3`:
```
from greatfet import GreatFET 
from greatfet.peripherals.gpio import J1, Directions

gf = GreatFET()
gf.gpio.setup(J1.P3, Directions.OUT)

state = True
while True:
    gf.gpio.output(J1.P3, state)
    state = not state
```
Read input `J1.P3` and set output `J1.P5`:
```
from greatfet import GreatFET 
from greatfet.peripherals.gpio import J1, Directions

gf = GreatFET()
gf.gpio.setup(J1.P3, Directions.IN)
gf.gpio.setup(J1.P5, Directions.OUT)

while True:
    state = gf.gpio.input(J1.P3)
    gf.gpio.output(J1.P5, state)
```
#### Limitations

 - Firmware has no support for reading the GPIO configuration.  In order to synchronize with the state of the GreatFET, this code must reset the GreatFET's GPIO state.  This should be fixed so GPIO state is never changed unless the user requests to change it.

- Firmware does not support configuring pull-up or pull-down resistors for inputs yet, so it is not supported here either.

- Firmware only allows GPIO registrations to be appended, not updated or removed.  Repeatedly switching a line between input and output mode will overflow the registrations.
